### PR TITLE
Fix space between "drop me a line at" and email

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "gatsby develop",
     "test": "npm run lint:js && npm run lint:css",
     "posttest": "npm run format",
-    "build": "gatbsy build",
+    "build": "gatsby build",
     "lint:js": "eslint . --fix",
     "lint:css": "stylelint 'src/**/*.js'",
     "format": "prettier --write '**/*.{js,md}'",

--- a/src/layouts/Index.js
+++ b/src/layouts/Index.js
@@ -62,7 +62,7 @@ const Index = ({
 				<Section level={3}>
 					<Subheading>Contact me</Subheading>
 					<Text size="l">
-						Drop me a line at
+						Drop me a line at{' '}
 						<Link href="mailto:artem@sapegin.ru" className="u-email">
 							artem@sapegin.ru
 						</Link>{' '}


### PR DESCRIPTION
Fix typo in package.json

### Found when I was working with styleguidist docs.

Before
<img width="620" alt="before-without-space" src="https://user-images.githubusercontent.com/5443359/58993333-e9289900-87f5-11e9-9387-9165bef5d792.png">

After
<img width="641" alt="after-with-space" src="https://user-images.githubusercontent.com/5443359/58993339-ed54b680-87f5-11e9-85b9-8e6d305dbd40.png">
